### PR TITLE
Add no shuffle mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ options:
                         each dataset has been read. Defaults to ${CONFIG}.state
   --sync                Do not shuffle in the background
   --do-not-resume, -d   Do not resume from the previous training state
+  --no-shuffle, -n      Do not shuffle, for debugging
 ```
 Once you fix the paths in the configuration file, `train_config.yml` you can run a test case by doing:
 ```bash
@@ -48,7 +49,7 @@ At the start of the training all datasets are shuffled. Each time a dataset's en
 ## Configuration file
 Define your training process via a configuration file. You define the datasets on top, the stages and then for each stage a mixing criteria and a stage termination criteria. An example configuration file is provided below. The path to the `trainer` is a path to any neural network trainer that supports having stdin as training input format.
 ```yml
-# Datasets are already TSV files
+# Datasets are already TSV files. We support reading gzip'd files, as well as multiple dataset file per name
 datasets:
   clean: test/data/clean
   medium: test/data/medium

--- a/contrib/test_enzh_config_plain.yml
+++ b/contrib/test_enzh_config_plain.yml
@@ -1,0 +1,13 @@
+# Datasets are already TSV files
+datasets:
+  clean: test-data/clean.enzh.10
+
+stages:
+  - start
+
+start:
+  - clean  1
+  - until clean 1
+
+seed: 1111
+trainer: cat

--- a/src/opustrainer/shuffle.py
+++ b/src/opustrainer/shuffle.py
@@ -167,7 +167,7 @@ def main() -> None:
 	parser.add_argument('--batch-size', type=int, default=1_000_000, help='number of lines per chunk. Note that these chunks are read into memory when being shuffled')
 	parser.add_argument('--threads', '-j', type=int, default=0, help=f'number of concurrent shuffle threads. Defaults to none')
 	parser.add_argument('--temporary-directory', '-T', type=str, help='temporary directory for shuffling batches')
-	parser.add_argument('--do-not-shuffle', '-d', action="store_true", help='Do not shuffle, to be used for debugging')
+	parser.add_argument('--no-shuffle', '-n', action="store_false", help='Do not shuffle, to be used for debugging', dest="shuffle")
 	parser.add_argument('seed', type=int)
 	parser.add_argument('output', type=FileType('wb', bufsize=BUFSIZE), default='-')
 	parser.add_argument('files', nargs='+')
@@ -178,7 +178,7 @@ def main() -> None:
 	it: Iterable[bytes] = chain.from_iterable(Reader(filename) for filename in args.files)
 
 	# Shuffle the lines
-	if not args.do_not_shuffle:
+	if args.shuffle:
 		it = shuffle(it, lines=args.batch_size, seed=args.seed, threads=args.threads, tmpdir=args.temporary_directory)
 
 	args.output.writelines(it)

--- a/src/opustrainer/shuffle.py
+++ b/src/opustrainer/shuffle.py
@@ -149,7 +149,7 @@ class Reader(Iterable[bytes]):
 		assert child.stdout is not None
 		yield from child.stdout
 		if child.wait() != 0:
-			raise RuntimeError(f'`gzip -cd {filename}` failed with return code {child.returncode}')		
+			raise RuntimeError(f'`{PATH_TO_GZIP} -cd {filename}` failed with return code {child.returncode}')
 
 	def _read_plain(self, filename:str) -> Iterable[bytes]:
 		with open(filename, 'rb') as fh:
@@ -167,6 +167,7 @@ def main() -> None:
 	parser.add_argument('--batch-size', type=int, default=1_000_000, help='number of lines per chunk. Note that these chunks are read into memory when being shuffled')
 	parser.add_argument('--threads', '-j', type=int, default=0, help=f'number of concurrent shuffle threads. Defaults to none')
 	parser.add_argument('--temporary-directory', '-T', type=str, help='temporary directory for shuffling batches')
+	parser.add_argument('--do-not-shuffle', '-d', action="store_true", help='Do not shuffle, to be used for debugging')
 	parser.add_argument('seed', type=int)
 	parser.add_argument('output', type=FileType('wb', bufsize=BUFSIZE), default='-')
 	parser.add_argument('files', nargs='+')
@@ -177,7 +178,8 @@ def main() -> None:
 	it: Iterable[bytes] = chain.from_iterable(Reader(filename) for filename in args.files)
 
 	# Shuffle the lines
-	it = shuffle(it, lines=args.batch_size, seed=args.seed, threads=args.threads, tmpdir=args.temporary_directory)
+	if not args.do_not_shuffle:
+		it = shuffle(it, lines=args.batch_size, seed=args.seed, threads=args.threads, tmpdir=args.temporary_directory)
 
 	args.output.writelines(it)
 

--- a/src/opustrainer/trainer.py
+++ b/src/opustrainer/trainer.py
@@ -115,12 +115,13 @@ class DatasetReader:
     seed: int
     line: int
     epoch: int
+    no_shuffle: bool
 
     tmpdir: Optional[str]
 
     _fh: Optional[TextIO] = None
 
-    def __init__(self, dataset:Dataset, seed:int, tmpdir:Optional[str]=None):
+    def __init__(self, dataset:Dataset, seed:int, tmpdir:Optional[str]=None, no_shuffle:bool=False):
         """
         Parameters
         ----------
@@ -136,6 +137,7 @@ class DatasetReader:
         self.tmpdir = tmpdir
         self.epoch = 0
         self.line = 0
+        self.no_shuffle = no_shuffle
 
     def state(self) -> DatasetState:
         return DatasetState(self.seed, self.line, self.epoch)
@@ -168,6 +170,7 @@ class DatasetReader:
         # sure if that has any performance or stability benefits/drawbacks.
         subprocess.check_call([sys.executable, PATH_TO_SHUFFLE,
             *(['--temporary-directory', self.tmpdir] if self.tmpdir else []),
+            *(['--do-not-shuffle'] if self.no_shuffle else []),
             str(self.seed),
             f'/dev/fd/{fh.fileno()}',
             *self.dataset.files
@@ -235,6 +238,7 @@ class AsyncDatasetReader(DatasetReader):
             file=cast(TextIO, fh),
             proc=subprocess.Popen([sys.executable, PATH_TO_SHUFFLE,
                 *(['--temporary-directory', self.tmpdir] if self.tmpdir else []),
+                *(['--do-not-shuffle'] if self.no_shuffle else []),
                 str(seed),
                 f'/dev/fd/{fh.fileno()}',
                 *self.dataset.files
@@ -519,16 +523,21 @@ class Trainer:
 
     # Path to write temporary shuffled files to
     tmpdir:Optional[str]
+    # For debugging purposes, whether to shuffle or not
+    no_shuffle:bool
 
     # Reader class to use (I.e. DatasetReader or AsyncDatasetReader)
     _reader_impl: Type[DatasetReader]
 
-    def __init__(self, curriculum:Curriculum, *, reader:Type[DatasetReader] = DatasetReader, tmpdir:Optional[str]=None):
+    def __init__(self, curriculum:Curriculum, *, reader:Type[DatasetReader] = DatasetReader, tmpdir:Optional[str]=None, no_shuffle:bool=False):
         self.curriculum = curriculum
         self.tmpdir = tmpdir
+        self.no_shuffle = no_shuffle
         self._reader_impl = reader
         random.seed(self.curriculum.seed)
         first_stage_name = self.curriculum.stages_order[0]
+        if (self.no_shuffle):
+            print("NO SHUFFLE: ", self.no_shuffle)
 
         #TODO: make sure this doesn't do too much work in case we call
         # restore() manually anyway.
@@ -546,7 +555,7 @@ class Trainer:
         random.setstate(state.random_state)
         self.stage = self.curriculum.stages[state.stage]
         self.readers = {
-            dataset.name: self._reader_impl(dataset, self.curriculum.seed, tmpdir=self.tmpdir).restore(state.datasets[dataset.name])
+            dataset.name: self._reader_impl(dataset, self.curriculum.seed, tmpdir=self.tmpdir, no_shuffle=self.no_shuffle).restore(state.datasets[dataset.name])
             for dataset in self.curriculum.datasets.values()
         }
         self.epoch_tracker = EpochTracker(self.readers[self.stage.until_dataset]).restore(state.epoch_tracker_state)
@@ -604,7 +613,8 @@ class Trainer:
                 for modifier in modifiers:
                     batch = [modifier(line.rstrip('\n')) + '\n' for line in batch]
 
-                random.shuffle(batch)
+                if not self.no_shuffle:
+                    random.shuffle(batch)
 
                 # Tell anyone whose listening that something interesting happened
                 # TODO: Yield something useful, e.g. progress.
@@ -682,6 +692,7 @@ def main() -> None:
     parser.add_argument("--sync", action="store_true", help="Do not shuffle async")
     parser.add_argument("--temporary-directory", '-T', default=None, type=str, help='Temporary dir, used for shuffling and tracking state')
     parser.add_argument("--do-not-resume", '-d', action="store_true", help='Do not resume from the previous training state')
+    parser.add_argument("--no-shuffle", '-n', action="store_true", help='Do not shuffle, for debugging')
     parser.add_argument("trainer", type=str, nargs=argparse.REMAINDER, help="Trainer program that gets fed the input. If empty it is read from config.")
 
     args = parser.parse_args()
@@ -697,7 +708,7 @@ def main() -> None:
         if missing_files:
             raise ValueError(f"Dataset '{dataset.name}' is missing files: {missing_files}")
 
-    trainer = Trainer(curriculum, reader=DatasetReader if args.sync else AsyncDatasetReader, tmpdir=args.temporary_directory)
+    trainer = Trainer(curriculum, reader=DatasetReader if args.sync else AsyncDatasetReader, tmpdir=args.temporary_directory, no_shuffle=args.no_shuffle)
 
     state_tracker = StateTracker(args.state or f'{args.config}.state', restore=not args.do_not_resume)
 

--- a/src/opustrainer/trainer.py
+++ b/src/opustrainer/trainer.py
@@ -115,13 +115,13 @@ class DatasetReader:
     seed: int
     line: int
     epoch: int
-    no_shuffle: bool
+    shuffle: bool
 
     tmpdir: Optional[str]
 
     _fh: Optional[TextIO] = None
 
-    def __init__(self, dataset:Dataset, seed:int, tmpdir:Optional[str]=None, no_shuffle:bool=False):
+    def __init__(self, dataset:Dataset, seed:int, tmpdir:Optional[str]=None, shuffle:bool=True):
         """
         Parameters
         ----------
@@ -131,13 +131,15 @@ class DatasetReader:
             Seed number for the random number generator that shuffles the data internally
         tmpdir : str, optional
             Path to directory in which the temporary shuffled dataset is written (default is `tempfile.gettempdir()`)
+        shuffle : bool
+            Indicates whether shuffling should happen. Enabled by default.
         """
         self.dataset = dataset
         self.seed = seed
         self.tmpdir = tmpdir
         self.epoch = 0
         self.line = 0
-        self.no_shuffle = no_shuffle
+        self.shuffle = shuffle
 
     def state(self) -> DatasetState:
         return DatasetState(self.seed, self.line, self.epoch)
@@ -170,7 +172,7 @@ class DatasetReader:
         # sure if that has any performance or stability benefits/drawbacks.
         subprocess.check_call([sys.executable, PATH_TO_SHUFFLE,
             *(['--temporary-directory', self.tmpdir] if self.tmpdir else []),
-            *(['--do-not-shuffle'] if self.no_shuffle else []),
+            *([] if self.shuffle else ['--no-shuffle']),
             str(self.seed),
             f'/dev/fd/{fh.fileno()}',
             *self.dataset.files
@@ -238,7 +240,7 @@ class AsyncDatasetReader(DatasetReader):
             file=cast(TextIO, fh),
             proc=subprocess.Popen([sys.executable, PATH_TO_SHUFFLE,
                 *(['--temporary-directory', self.tmpdir] if self.tmpdir else []),
-                *(['--do-not-shuffle'] if self.no_shuffle else []),
+                *([] if self.shuffle else ['--no-shuffle']),
                 str(seed),
                 f'/dev/fd/{fh.fileno()}',
                 *self.dataset.files
@@ -524,20 +526,18 @@ class Trainer:
     # Path to write temporary shuffled files to
     tmpdir:Optional[str]
     # For debugging purposes, whether to shuffle or not
-    no_shuffle:bool
+    shuffle:bool
 
     # Reader class to use (I.e. DatasetReader or AsyncDatasetReader)
     _reader_impl: Type[DatasetReader]
 
-    def __init__(self, curriculum:Curriculum, *, reader:Type[DatasetReader] = DatasetReader, tmpdir:Optional[str]=None, no_shuffle:bool=False):
+    def __init__(self, curriculum:Curriculum, *, reader:Type[DatasetReader] = DatasetReader, tmpdir:Optional[str]=None, shuffle:bool=True):
         self.curriculum = curriculum
         self.tmpdir = tmpdir
-        self.no_shuffle = no_shuffle
+        self.shuffle = shuffle
         self._reader_impl = reader
         random.seed(self.curriculum.seed)
         first_stage_name = self.curriculum.stages_order[0]
-        if (self.no_shuffle):
-            print("NO SHUFFLE: ", self.no_shuffle)
 
         #TODO: make sure this doesn't do too much work in case we call
         # restore() manually anyway.
@@ -555,7 +555,7 @@ class Trainer:
         random.setstate(state.random_state)
         self.stage = self.curriculum.stages[state.stage]
         self.readers = {
-            dataset.name: self._reader_impl(dataset, self.curriculum.seed, tmpdir=self.tmpdir, no_shuffle=self.no_shuffle).restore(state.datasets[dataset.name])
+            dataset.name: self._reader_impl(dataset, self.curriculum.seed, tmpdir=self.tmpdir, shuffle=self.shuffle).restore(state.datasets[dataset.name])
             for dataset in self.curriculum.datasets.values()
         }
         self.epoch_tracker = EpochTracker(self.readers[self.stage.until_dataset]).restore(state.epoch_tracker_state)
@@ -613,7 +613,7 @@ class Trainer:
                 for modifier in modifiers:
                     batch = [modifier(line.rstrip('\n')) + '\n' for line in batch]
 
-                if not self.no_shuffle:
+                if self.shuffle:
                     random.shuffle(batch)
 
                 # Tell anyone whose listening that something interesting happened
@@ -692,7 +692,7 @@ def main() -> None:
     parser.add_argument("--sync", action="store_true", help="Do not shuffle async")
     parser.add_argument("--temporary-directory", '-T', default=None, type=str, help='Temporary dir, used for shuffling and tracking state')
     parser.add_argument("--do-not-resume", '-d', action="store_true", help='Do not resume from the previous training state')
-    parser.add_argument("--no-shuffle", '-n', action="store_true", help='Do not shuffle, for debugging')
+    parser.add_argument("--no-shuffle", '-n', action="store_false", help='Do not shuffle, for debugging', dest="shuffle")
     parser.add_argument("trainer", type=str, nargs=argparse.REMAINDER, help="Trainer program that gets fed the input. If empty it is read from config.")
 
     args = parser.parse_args()
@@ -708,7 +708,7 @@ def main() -> None:
         if missing_files:
             raise ValueError(f"Dataset '{dataset.name}' is missing files: {missing_files}")
 
-    trainer = Trainer(curriculum, reader=DatasetReader if args.sync else AsyncDatasetReader, tmpdir=args.temporary_directory, no_shuffle=args.no_shuffle)
+    trainer = Trainer(curriculum, reader=DatasetReader if args.sync else AsyncDatasetReader, tmpdir=args.temporary_directory, shuffle=args.shuffle)
 
     state_tracker = StateTracker(args.state or f'{args.config}.state', restore=not args.do_not_resume)
 

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -25,3 +25,17 @@ class TestEndToEnd(unittest.TestCase):
 		with open('contrib/test-data/test_zhen_config_prefix.expected.out', 'r', encoding='utf-8') as reffile:
 			reference: str = "".join(reffile.readlines())
 		self.assertEqual(output, reference)
+
+	def test_no_shuffle(self):
+		output: str = subprocess.check_output([sys.executable, '-m', 'opustrainer', '-c', 'contrib/test_enzh_config_plain.yml', '-d', '-n'], encoding="utf-8")
+		reference: str = ""
+		with open('contrib/test-data/clean.enzh.10', 'r', encoding='utf-8') as reffile:
+			reference: str = "".join(reffile.readlines())
+		# Since we read 100 lines at a time, we wrap. Often.
+		# Hence, for the test to pass we need to read the number of lines in the test file
+		reference_arr = reference.split('\n')
+		output_arr = output.split('\n')
+		for i in range(len(reference_arr)):
+			# Skip final empty newline
+			if reference_arr[i] != '':
+				self.assertEqual(output_arr[i], reference_arr[i])


### PR DESCRIPTION
I used the shuffler and added a do not shuffle flag to it, because it also reads multiple datasets into one which is useful if we don't want to concatenate. I also fixed a few small issues in the readme and the error output