### PR TITLE
Dump state file by write+move vs overwrite

### DIFF
--- a/src/opustrainer/trainer.py
+++ b/src/opustrainer/trainer.py
@@ -690,8 +690,10 @@ class StateTracker:
             return trainer.restore(self.loader.load(fh))
 
     def _dump(self, trainer:Trainer):
-        with open(self.path, 'w', encoding='utf-8') as fh:
-            return self.loader.dump(trainer.state(), fh)
+        new_statefile = f"{self.path}.new"
+        with open(new_statefile, 'w', encoding='utf-8') as fh:
+            self.loader.dump(trainer.state(), fh)
+        os.rename(new_statefile, self.path)
         self._last_dump = time.monotonic()
 
     def run(self, trainer:Trainer, *args, **kwargs):


### PR DESCRIPTION
Haven't fully debugged this, but I was encountering issues when running in slurm, where the state-file would be empty after the previous job has finished. Resuming from an empty state file results in an immediate exit, and kills the array jobs.

Looking at the code there's a return statement before `_last_dump` is updated, which I guess causes the file to be overwritten each batch after the initial timeout period has passed.

I have slurm send sigterm 2-minutes before the job is killed, but perhaps this isn't enough time for the child process to be stopped nicely. I'm running on a slurm cluster which only tracks stdout, so I'm missing the opustrainer output on stderr to see what actually went on during shutdown. In any case writing to an adjacent file, and moving over the old state might provide some more resilience against more sudden shutdowns.

