### PR TITLE
Fixes + num_field assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,12 @@ modifiers:
 - TitleCase: 0.05
 
 seed: 1111
+num_fields: 2 # Assures every line has exactly 2 fields.
 trainer: /path/to/trainer/run.py
 ```
+
+### Number of fields
+If `num_fields` is provided, at read time, the trainer will strip any extra TSV fields that the dataset contains (such as optinal alignment field that you are not going to use). Furthermore, any line that doesn't have enough fields gets filtered (eg lines missing alignment info when you do actually care about alignment).
 
 ### Extended stage configuration
 If you want to change which modifiers are used for a specific stage, you can the extended stage configuration format. If a `modifiers` is mentioned here, it will override the curriculum-wide defined `modifiers` for just this stage.

--- a/src/opustrainer/trainer.py
+++ b/src/opustrainer/trainer.py
@@ -11,13 +11,10 @@ import random
 import subprocess
 import time
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import Enum
-from typing import List, Tuple, Dict, Set, Any, Optional, Union, Type, TextIO, cast, Iterable, Literal, Iterable, Callable, TypeVar, get_type_hints, get_args, get_origin
+from typing import List, Tuple, Dict, Any, Optional, Union, Type, TextIO, cast, Iterable, Iterable, Callable, TypeVar, get_type_hints, get_args, get_origin
 from tempfile import TemporaryFile
 from itertools import islice
-from functools import partial
 from pathlib import Path
 
 import yaml
@@ -219,12 +216,10 @@ class DatasetReader:
         return self
 
     def __next__(self) -> str:
-        just_opened = False
         if not self._fh or self._fh.closed:
             self._open() # TODO: do we want to do this lazy? Yes, restore()
                          # might be called twice right now and shuffling is
                          # expensive.
-            just_opened = True
 
         assert self._fh is not None
         line = self._next_line


### PR DESCRIPTION
Various fixes (Mostly variable name typos that would crash the trainer if that line was ever executed)
Removed unused var and imports

Added explicit `num_fields` option to the YML so that we don't have to run TAGS everywhere.

This is also in preparation for passing `num_fields` to tags, so that we can output alignment info and train with guided alignment.