### PR TITLE
Add more information to the log on the current stage

### DIFF
--- a/contrib/test-data/test_enzh_config_plain_expected.log
+++ b/contrib/test-data/test_enzh_config_plain_expected.log
@@ -1,4 +1,5 @@
-[2023-07-04 02:48:11] [Trainer] [INFO] Starting stage start
+[2023-07-04 02:48:11] [Trainer] [INFO] Starting stage: "start"
+[2023-07-04 02:48:11] [Trainer] [INFO] Running until dataset "clean" for 1 epoch(s)
 [2023-07-04 02:48:11] [Trainer] [INFO] Reading clean for epoch 0
 [2023-07-04 02:48:11] [Trainer] [INFO] Reading clean for epoch 1
 [2023-07-04 02:48:11] [Trainer] [INFO] Reading clean for epoch 2
@@ -9,4 +10,5 @@
 [2023-07-04 02:48:12] [Trainer] [INFO] Reading clean for epoch 7
 [2023-07-04 02:48:12] [Trainer] [INFO] Reading clean for epoch 8
 [2023-07-04 02:48:12] [Trainer] [INFO] Reading clean for epoch 9
+[2023-07-04 02:48:12] [Trainer] [INFO] Finished the last stage
 [2023-07-04 02:48:12] [Trainer] [INFO] waiting for trainer to exit. Press ctrl-c to be more aggressive


### PR DESCRIPTION
We're using OpusTrainer in Firefox Translations, and I was finding some of the OpusTrainer behavior confusing. This PR adds some more logs to explain a bit more what is going on.

Example output:

```
[2024-09-13 15:46:33] [Trainer] [INFO] Starting stage: "train"
[2024-09-13 15:46:33] [Trainer] [INFO] Running until dataset "original" for 1 epoch(s)
[2024-09-13 15:46:33] [Trainer] [INFO] Using curriculum modifiers:
[2024-09-13 15:46:33] [Trainer] [INFO]  - UpperCaseModifier (0.07)
[2024-09-13 15:46:33] [Trainer] [INFO]  - TitleCaseModifier (0.05)
[2024-09-13 15:46:33] [Trainer] [INFO]  - TypoModifier (0.05)
[2024-09-13 15:46:33] [Trainer] [INFO]  - NoiseModifier (0.0005)
[2024-09-13 15:46:33] [Trainer] [INFO] Reading original for epoch 0
[2024-09-13 15:46:34] [Trainer] [INFO] Reading original for epoch 1
[2024-09-13 15:46:34] [Trainer] [INFO] Finished the last stage
[2024-09-13 15:46:34] [Trainer] [INFO] waiting for trainer to exit. Press ctrl-c to be more aggressive
```